### PR TITLE
fix: a zero-length pomodoro no longer fires the celebration every tick

### DIFF
--- a/src/NotesManager.swift
+++ b/src/NotesManager.swift
@@ -356,7 +356,20 @@ final class NotesManager: ObservableObject {
         let ns = text as NSString
         guard let match = regex.firstMatch(in: text, range: NSRange(location: 0, length: ns.length)),
               let workMinutes = Int(ns.substring(with: match.range(at: 1))),
-              let breakMinutes = Int(ns.substring(with: match.range(at: 2)))
+              let breakMinutes = Int(ns.substring(with: match.range(at: 2))),
+              // Both halves must be a real duration. A cycle alternates
+              // between them forever, so a zero-length phase fires the
+              // instant it starts: "pomodoro 0/0" put the app in a tight
+              // loop firing the celebration (a full-screen confetti window
+              // and a sound) on every single tick, with no way out but
+              // editing the directive away. "pomodoro 0/5" is the same
+              // fault spread thinner, a celebration every five minutes
+              // forever. A plain "0m timer" is unaffected and still fires
+              // once, because a timer ends rather than repeating.
+              // Rejecting the directive here rather than clamping it means
+              // degenerate text stays inert, the same way any other
+              // unparseable line does.
+              workMinutes > 0, breakMinutes > 0
         else { return nil }
 
         return PomodoroDirective(

--- a/tests/NotesManagerTests.swift
+++ b/tests/NotesManagerTests.swift
@@ -347,6 +347,37 @@ func runAllTests() {
         )
     }
 
+    // A cycle alternates between its two phases forever, so a zero-length
+    // phase fires the instant it starts. "pomodoro 0/0" used to put the app
+    // in a tight loop, firing the celebration on every tick with no way out
+    // but editing the directive away. Both halves have to be real durations
+    // for the directive to count at all.
+    suite("a pomodoro phase of zero minutes is not a directive") {
+        equal(NotesManager.firstPomodoroDirective(in: "pomodoro 0/0")?.source, nil, "both halves zero")
+        equal(NotesManager.firstPomodoroDirective(in: "pomodoro 0/5")?.source, nil, "zero work")
+        equal(NotesManager.firstPomodoroDirective(in: "pomodoro 25/0")?.source, nil, "zero break")
+        equal(NotesManager.firstPomodoroDirective(in: "pomodoro 1/1")?.workDuration, 60, "one minute each is fine")
+    }
+
+    // Drives the real per-tick loop `ContentView.updateTimer` runs, counting
+    // how many times the celebration would fire. The bug this covers was not
+    // visible in the parser alone: it only appeared once a fired phase
+    // scheduled the next one.
+    suite("a zero-length pomodoro does not fire the celebration on every tick") {
+        let manager = makeManager()
+        manager.currentText = "pomodoro 0/0"
+        var fires = 0
+        for _ in 0..<12 {
+            guard let end = manager.activeTimerEnd else { break }
+            if end.timeIntervalSince(Date()) <= 0 {
+                fires += 1
+                manager.timerDidFire()
+            }
+        }
+        equal(fires, 0, "twelve ticks, no celebration, because the directive never starts")
+        equal(manager.activeTimerEnd, nil, "and nothing is counting down")
+    }
+
     suite("a pomodoro cycle starts in the work phase and alternates when it fires") {
         let m = makeManager()
         m.currentText = "pomodoro 25/5"


### PR DESCRIPTION
Typing "pomodoro 0/0" started a cycle whose work phase was already over the moment it began. timerDidFire flips the phase and immediately schedules the next one, so every tick fired the celebration again: a full-screen confetti window and a sound, once per second, indefinitely, with no way out but editing the directive away. Reproduced by driving the same per-tick loop ContentView.updateTimer runs: 12 celebrations in 12 ticks, against 1 for a plain "0m timer".

"pomodoro 0/5" is the same fault spread thinner, a celebration every five minutes forever. Plain timers are unaffected, because a timer ends rather than repeating.

Both halves must now be a real duration for the directive to parse at all, so degenerate text stays inert the way any other unparseable line does. Rejecting rather than clamping keeps one rule instead of two.

Six new checks in tests/NotesManagerTests.swift, five of which fail without this change. ./test.sh 648/648.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pomodoro timers now reject work or break phases set to zero minutes.
  * Prevented zero-duration pomodoro cycles from repeatedly triggering completion events.
  * Plain timers continue to support their existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->